### PR TITLE
fixed sending of window number from Metronome

### DIFF
--- a/GUI/examples/gem_example_multitempo.py
+++ b/GUI/examples/gem_example_multitempo.py
@@ -39,7 +39,7 @@ presets = {
     "hfile": os.path.join(os.environ['GEMROOT'],"GEM/GEMConstants.h"),
 
     # number of players in the experiment. NB: all 4 tapper Arduinos can remain attached to metronome Arduino
-    "tappers_requested": 4,
+    "tappers_requested": 2,
 
     # metronome adaptivity levels to be used
     "metronome_alpha": [0, .3, 1],
@@ -51,7 +51,7 @@ presets = {
     "repeats": 1,
 
     # number of metronome clicks
-    "windows": 10,
+    "windows": 20,
 
     # audio feedback condition; NB: at present, only "hear_metronome" available.
     # Future releases will allow for all variations on hearing self, metronome,

--- a/Metronome/Metronome.ino
+++ b/Metronome/Metronome.ino
@@ -479,7 +479,8 @@ void run()
                 Serial.write(GEM_DTP_RAW);
 
                 // Send current window to ECC - 20170703 LF
-                Serial.write((byte *)window, sizeof (uint16_t));
+                //Serial.write((byte *)window, sizeof (uint16_t));
+                Serial.write((byte *)&window, sizeof (uint16_t));
 
                 /*NOTE: next, send the scheduled time of the metronome tone for
                 this window, which is what the asynchronies are relative too, see

--- a/Metronome/Metronome.ino
+++ b/Metronome/Metronome.ino
@@ -478,8 +478,7 @@ void run()
                 //first byte is the data transfer protocol identifier
                 Serial.write(GEM_DTP_RAW);
 
-                // Send current window to ECC - 20170703 LF
-                //Serial.write((byte *)window, sizeof (uint16_t));
+                // Send current window to ECC
                 Serial.write((byte *)&window, sizeof (uint16_t));
 
                 /*NOTE: next, send the scheduled time of the metronome tone for


### PR DESCRIPTION
Had to provide address to the byte pointer cast for the window variable rather than window value itself.